### PR TITLE
Use HTTP API directly, reduce dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ Neo4J for XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 0.2.0 / 2017-09-30
+
+* Changed Graph constructor to accept URLs or HttpConnection instances
+  (@thekid)
+* Merged PR #1: Use HTTP API directly, reduce dependencies - @thekid
+* Added `toString()` method to `com.neo4j.Graph` class - @thekid
+
 ## 0.1.0 / 2017-09-30
 
 * First public release - (@thekid)

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
-    "xp-framework/rest": "^9.0 | ^8.3",
+    "xp-framework/http": "^9.0 | ^8.0",
+    "xp-forge/json": "^3.0 | ^2.2",
     "php" : ">=5.6.0"
   },
   "require-dev" : {

--- a/src/main/php/com/neo4j/Graph.class.php
+++ b/src/main/php/com/neo4j/Graph.class.php
@@ -20,7 +20,7 @@ class Graph implements \lang\Value {
   /**
    * Creates a new Neo4J graph connection
    *
-   * @param  string|peer.http.HttpConnection $endpoint
+   * @param  string|peer.URL|peer.http.HttpConnection $endpoint
    */
   public function __construct($endpoint) {
     $this->conn= $endpoint instanceof HttpConnection ? $endpoint : new HttpConnection($endpoint);

--- a/src/main/php/com/neo4j/Graph.class.php
+++ b/src/main/php/com/neo4j/Graph.class.php
@@ -1,7 +1,11 @@
 <?php namespace com\neo4j;
 
-use webservices\rest\Endpoint;
-use webservices\rest\RestFormat;
+use peer\http\HttpConnection;
+use peer\http\HttpRequest;
+use peer\http\RequestData;
+use text\json\Json;
+use text\json\Format;
+use text\json\StreamInput;
 
 /**
  * Neo4J interface using its HTTP API
@@ -11,16 +15,18 @@ use webservices\rest\RestFormat;
  * @test  xp://com.neo4j.unittest.GraphTest
  */
 class Graph implements \lang\Value {
-  private $endpoint, $cypher;
+  private $conn, $cypher, $json, $base;
 
   /**
    * Creates a new Neo4J graph connection
    *
-   * @param  string $url
+   * @param  string|peer.http.HttpConnection $endpoint
    */
-  public function __construct($url) {
-    $this->endpoint= new Endpoint($url);
+  public function __construct($endpoint) {
+    $this->conn= $endpoint instanceof HttpConnection ? $endpoint : new HttpConnection($endpoint);
     $this->cypher= new Cypher();
+    $this->json= Format::dense();
+    $this->base= rtrim($this->conn->getURL()->getPath(), '/');
   }
 
   /**
@@ -30,7 +36,19 @@ class Graph implements \lang\Value {
    * @return [:var] Results
    */
   protected function commit($payload) {
-    return $this->endpoint->resource('transaction/commit')->with(['X-Stream' => 'true'])->post($payload, RestFormat::$JSON)->data();
+    $req= $this->conn->create(new HttpRequest());
+    $req->setMethod('POST');
+    $req->setTarget($this->base.'/transaction/commit');
+    $req->setHeader('X-Stream', 'true');
+    $req->setHeader('Content-Type', 'application/json');
+    $req->setParameters(new RequestData(Json::of($payload, $this->json)));
+
+    $res= $this->conn->send($req);
+    if (200 !== $res->statusCode()) {
+      throw new QueryFailed(['Unexpected HTTP response status '.$res->statusCode()]);
+    }
+
+    return Json::read(new StreamInput($res->in()));
   }
 
   /**
@@ -95,7 +113,7 @@ class Graph implements \lang\Value {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'(->'.$this->endpoint->toString().')';
+    return nameof($this).'(->'.$this->conn->toString().')';
   }
 
   /** @return string */

--- a/src/test/php/com/neo4j/unittest/GraphTest.class.php
+++ b/src/test/php/com/neo4j/unittest/GraphTest.class.php
@@ -4,6 +4,8 @@ use com\neo4j\Graph;
 use com\neo4j\QueryFailed;
 use lang\FormatException;
 use lang\IndexOutOfBoundsException;
+use peer\URL;
+use peer\http\HttpConnection;
 
 class GraphTest extends \unittest\TestCase {
   public static $ROW = ['columns' => ['id(n)'], 'data' => [['row' => [6], 'meta' => [null]]]];
@@ -38,6 +40,16 @@ class GraphTest extends \unittest\TestCase {
   #[@test]
   public function can_create() {
     new Graph('http://localhost:7474/db/data');
+  }
+
+  #[@test]
+  public function can_create_with_url() {
+    new Graph(new URL('http://localhost:7474/db/data'));
+  }
+
+  #[@test]
+  public function can_create_with_http_connection() {
+    new Graph(new HttpConnection('http://localhost:7474/db/data'));
   }
 
   #[@test]


### PR DESCRIPTION
## Previous dependencies (for PHP 7)

xp-framework/core (v9.1.0)
xp-forge/json (v3.0.2)
xp-framework/tokenize (v8.0.0)
xp-framework/networking (v9.0.0)
xp-framework/collections (v8.0.0)
xp-framework/logging (v8.0.0)
xp-framework/text-encode (v8.0.0)
xp-framework/mail (v8.0.0)
xp-framework/math (v8.0.0)
xp-framework/rdbms (v10.0.0)
xp-framework/xml (v9.0.0)
xp-framework/http (v9.0.0)
xp-framework/scriptlet (v9.0.0)
xp-framework/rest (v9.0.1)
xp-framework/unittest (v9.2.0)

## New dependencies (also on PHP 7)

xp-framework/core (v9.1.0)
xp-framework/networking (v9.0.0)
xp-framework/logging (v8.0.0)
xp-framework/http (v9.0.0)
xp-forge/json (v3.0.2)
xp-framework/unittest (v9.2.0)
