### PR TITLE
Add fetch() method to return single result, or NULL

### DIFF
--- a/src/main/php/com/neo4j/Graph.class.php
+++ b/src/main/php/com/neo4j/Graph.class.php
@@ -88,6 +88,20 @@ class Graph implements \lang\Value {
   }
 
   /**
+   * Runs a single query and returns its single result, or NULL
+   *
+   * @param  string $cypher
+   * @param  var... $args
+   * @return var
+   */
+  public function fetch($cypher, ... $args) {
+    foreach ($this->open($cypher, ...$args) as $result) {
+      return $result;
+    }
+    return null;
+  }
+
+  /**
    * Executes multiple statements
    *
    * @param  [:var][] $statements

--- a/src/main/php/com/neo4j/Graph.class.php
+++ b/src/main/php/com/neo4j/Graph.class.php
@@ -81,10 +81,19 @@ class Graph implements \lang\Value {
    *
    * @param  string $cypher
    * @param  var... $args
-   * @return iterable
+   * @return var[]
    */
   public function query($cypher, ... $args) {
-    return iterator_to_array($this->open($cypher, ...$args));
+    $return= [];
+    $result= $this->execute([$this->cypher->format($cypher, ...$args)])[0];
+    foreach ($result['data'] as $data) {
+      $record= [];
+      foreach ($data['row'] as $i => $value) {
+        $record[$result['columns'][$i]]= $value;
+      }
+      $return[]= $record;
+    }
+    return $return;
   }
 
   /**
@@ -95,8 +104,13 @@ class Graph implements \lang\Value {
    * @return var
    */
   public function fetch($cypher, ... $args) {
-    foreach ($this->open($cypher, ...$args) as $result) {
-      return $result;
+    $result= $this->execute([$this->cypher->format($cypher, ...$args)])[0];
+    foreach ($result['data'] as $data) {
+      $record= [];
+      foreach ($data['row'] as $i => $value) {
+        $record[$result['columns'][$i]]= $value;
+      }
+      return $record;
     }
     return null;
   }
@@ -122,14 +136,10 @@ class Graph implements \lang\Value {
   }
 
   /** @return string */
-  public function toString() {
-    return nameof($this).'(->'.$this->conn->toString().')';
-  }
+  public function toString() { return nameof($this).'(->'.$this->conn->toString().')'; }
 
   /** @return string */
-  public function hashCode() {
-    return spl_object_hash($this);
-  }
+  public function hashCode() { return spl_object_hash($this); }
 
   /**
    * Comparison

--- a/src/main/php/com/neo4j/Graph.class.php
+++ b/src/main/php/com/neo4j/Graph.class.php
@@ -1,5 +1,6 @@
 <?php namespace com\neo4j;
 
+use lang\Value;
 use peer\http\{HttpConnection, HttpRequest, RequestData};
 use text\json\{Format, Json, StreamInput};
 
@@ -10,7 +11,7 @@ use text\json\{Format, Json, StreamInput};
  * @see   https://neo4j.com/blog/streaming-rest-api-interview-with-michael-hunger/
  * @test  xp://com.neo4j.unittest.GraphTest
  */
-class Graph implements \lang\Value {
+class Graph implements Value {
   private $conn, $cypher, $json, $base;
 
   /**

--- a/src/test/php/com/neo4j/unittest/GraphTest.class.php
+++ b/src/test/php/com/neo4j/unittest/GraphTest.class.php
@@ -108,6 +108,14 @@ class GraphTest extends TestCase {
     $this->assertEquals(null, $fixture->fetch('...'));
   }
 
+  #[Test, Expect(QueryFailed::class)]
+  public function fetch_raises_error() {
+    $fixture= $this->newFixture(function($payload) {
+      return ['results' => [], 'errors' => [['code' => 'Neo.ClientError.Statement.SyntaxError', 'message' => '...']]];
+    });
+    $fixture->fetch('...');
+  }
+
   #[Test]
   public function execute_returns_result() {
     $fixture= $this->newFixture(function($payload) {

--- a/src/test/php/com/neo4j/unittest/GraphTest.class.php
+++ b/src/test/php/com/neo4j/unittest/GraphTest.class.php
@@ -8,6 +8,7 @@ use unittest\{Expect, Test, TestCase};
 
 class GraphTest extends TestCase {
   public static $ROW = ['columns' => ['id(n)'], 'data' => [['row' => [6], 'meta' => [null]]]];
+  public static $EMPTY = ['columns' => [], 'data' => []];
   private static $ECHO;
 
   static function __static() {
@@ -52,11 +53,19 @@ class GraphTest extends TestCase {
   }
 
   #[Test]
-  public function query_returns_result() {
+  public function query_returns_results() {
     $fixture= $this->newFixture(function($payload) {
-      return ['results' => [GraphTest::$ROW], 'errors' => []];
+      return ['results' => [self::$ROW], 'errors' => []];
     });
     $this->assertEquals([['id(n)' => 6]], $fixture->query('...'));
+  }
+
+  #[Test]
+  public function query_returns_empty_array_for_no_results() {
+    $fixture= $this->newFixture(function($payload) {
+      return ['results' => [self::$EMPTY], 'errors' => []];
+    });
+    $this->assertEquals([], $fixture->query('...'));
   }
 
   #[Test, Expect(QueryFailed::class)]
@@ -84,11 +93,27 @@ class GraphTest extends TestCase {
   }
 
   #[Test]
+  public function fetch_returns_single_result() {
+    $fixture= $this->newFixture(function($payload) {
+      return ['results' => [self::$ROW], 'errors' => []];
+    });
+    $this->assertEquals(['id(n)' => 6], $fixture->fetch('...'));
+  }
+
+  #[Test]
+  public function fetch_returns_null_for_no_results() {
+    $fixture= $this->newFixture(function($payload) {
+      return ['results' => [self::$EMPTY], 'errors' => []];
+    });
+    $this->assertEquals(null, $fixture->fetch('...'));
+  }
+
+  #[Test]
   public function execute_returns_result() {
     $fixture= $this->newFixture(function($payload) {
-      return ['results' => [GraphTest::$ROW], 'errors' => []];
+      return ['results' => [self::$ROW], 'errors' => []];
     });
-    $this->assertEquals([GraphTest::$ROW], $fixture->execute(['...']));
+    $this->assertEquals([self::$ROW], $fixture->execute(['...']));
   }
 
   #[Test, Expect(QueryFailed::class)]


### PR DESCRIPTION
Currently, this is often done as follows:

```php
$topic= $graph->query('match (t:Topic{id:%s}) return t', $id);
if (empty($topic)) {
  throw new Error(404, 'No such entity '.$id);
}

return View::named('topic')->with(['topic' => $topic[0]);
```

With `fetch()`, this can be simplified a bit, e.g. by using `?? throw new Error(404, ...)` or by using `util.data.Optional`'s APIs, e.g.